### PR TITLE
Fix some bugs: support micro-batched denoising

### DIFF
--- a/composable_lora.py
+++ b/composable_lora.py
@@ -23,13 +23,16 @@ def load_prompt_loras(prompt: str):
 
 def reset_text_model_encoder_counter():
     global text_model_encoder_counter
+    global diff_model_layer_counter
 
     # reset counter to uc head
-    text_model_encoder_counter = len(prompt_loras) * 2
+    text_model_encoder_counter = -1
+    diff_model_layer_counter = 0
 
 
 def lora_forward(compvis_module, input, res):
     global text_model_encoder_counter
+    global diff_model_layer_counter
 
     import lora
 
@@ -39,6 +42,10 @@ def lora_forward(compvis_module, input, res):
     lora_layer_name: str | None = getattr(compvis_module, 'lora_layer_name', None)
     if lora_layer_name is None:
         return res
+
+    num_loras = len(lora.loaded_loras)
+    if text_model_encoder_counter == -1:
+        text_model_encoder_counter = len(prompt_loras) * num_loras
 
     # print(f"lora.forward lora_layer_name={lora_layer_name} in.shape={input.shape} res.shape={res.shape}")
 
@@ -63,9 +70,9 @@ def lora_forward(compvis_module, input, res):
                 #
                 # This code evaluated twice in get_learned_conditioning.
                 #
-                if 0 <= text_model_encoder_counter // 2 < len(prompt_loras):
+                if 0 <= text_model_encoder_counter // num_loras < len(prompt_loras):
                     # c
-                    loras = prompt_loras[text_model_encoder_counter // 2]
+                    loras = prompt_loras[text_model_encoder_counter // num_loras]
                     multiplier = loras.get(lora.name, 0.0)
                     if multiplier != 0.0:
                         # print(f"c #{text_model_encoder_counter // 2} lora.name={lora.name} mul={multiplier}")
@@ -79,29 +86,51 @@ def lora_forward(compvis_module, input, res):
                 if lora_layer_name.endswith("_11_mlp_fc2"):  # last
                     text_model_encoder_counter += 1
                     # c1 c1 c2 c2 .. .. uc uc
-                    if text_model_encoder_counter == len(prompt_loras) * 2 + 2:
+                    if text_model_encoder_counter == (len(prompt_loras) + 1) * num_loras:
                         text_model_encoder_counter = 0
 
-            elif res.shape[0] == num_batches * num_prompts + num_batches:  # "diffusion_model_"
-                #
-                #
-                #
-                tensor_off = 0
-                uncond_off = num_batches * num_prompts
-                for b in range(num_batches):
-                    # c
-                    for p, loras in enumerate(prompt_loras):
-                        multiplier = loras.get(lora.name, 0.0)
-                        if multiplier != 0.0:
-                            # print(f"tensor #{b}.{p} lora.name={lora.name} mul={multiplier}")
-                            res[tensor_off] += multiplier * alpha * patch[tensor_off]
-                        tensor_off += 1
+            elif lora_layer_name.startswith("diffusion_model_"): # "diffusion_model_"
 
-                    # uc
-                    if opt_uc_diffusion_model and lora.multiplier != 0.0:
-                        # print(f"uncond lora.name={lora.name} lora.mul={lora.multiplier}")
-                        res[uncond_off] += lora.multiplier * alpha * patch[uncond_off]
-                    uncond_off += 1
+                if res.shape[0] == num_batches * num_prompts + num_batches:
+                    #
+                    #
+                    #
+                    tensor_off = 0
+                    uncond_off = num_batches * num_prompts
+                    for b in range(num_batches):
+                        # c
+                        for p, loras in enumerate(prompt_loras):
+                            multiplier = loras.get(lora.name, 0.0)
+                            if multiplier != 0.0:
+                                print(f"tensor #{b}.{p} lora.name={lora.name} mul={multiplier}")
+                                res[tensor_off] += multiplier * alpha * patch[tensor_off]
+                            tensor_off += 1
+
+                        # uc
+                        if opt_uc_diffusion_model and lora.multiplier != 0.0:
+                            # print(f"uncond lora.name={lora.name} lora.mul={lora.multiplier}")
+                            res[uncond_off] += lora.multiplier * alpha * patch[uncond_off]
+                        uncond_off += 1
+                else:
+                    cur_num_prompts = int(res.shape[0])
+                    base = (diff_model_layer_counter // cur_num_prompts) // num_loras * cur_num_prompts
+                    if 0 <= base < len(prompt_loras):
+                        # c
+                        for off in range(cur_num_prompts):
+                            loras = prompt_loras[base + off]
+                            multiplier = loras.get(lora.name, 0.0)
+                            if multiplier != 0.0:
+                                res[off] += multiplier * alpha * patch[off]
+                    else:
+                        # uc
+                        if opt_uc_diffusion_model and lora.multiplier != 0.0:
+                            res += lora.multiplier * alpha * patch
+
+                    if lora_layer_name.endswith("_output_blocks_11_1_proj_out"):
+                        diff_model_layer_counter += cur_num_prompts
+                        if diff_model_layer_counter >= (len(prompt_loras) + 1) * num_loras:
+                            diff_model_layer_counter = 0
+
             else:
                 # default
                 if lora.multiplier != 0.0:
@@ -131,3 +160,4 @@ opt_uc_diffusion_model = False
 num_batches: int = 0
 prompt_loras: List[Dict[str, float]] = []
 text_model_encoder_counter: int = 0
+diff_model_layer_counter: int = 0


### PR DESCRIPTION
Previous version neglected the following case, where sub-prompts are packed into several micro-batches and fed into diffusion-model：
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/0cc0ee1bcb4c24a8c9715f66cede06601bfc00c8/modules/sd_samplers_kdiffusion.py#L124-L138
```python
        else:
            x_out = torch.zeros_like(x_in)
            batch_size = batch_size*2 if shared.batch_cond_uncond else batch_size
            for batch_offset in range(0, tensor.shape[0], batch_size):
                a = batch_offset
                b = min(a + batch_size, tensor.shape[0])


                if not is_edit_model:
                    c_crossattn = [tensor[a:b]]
                else:
                    c_crossattn = torch.cat([tensor[a:b]], uncond)


                x_out[a:b] = self.inner_model(x_in[a:b], sigma_in[a:b], cond={"c_crossattn": c_crossattn, "c_concat": [image_cond_in[a:b]]})


            x_out[-uncond.shape[0]:] = self.inner_model(x_in[-uncond.shape[0]:], sigma_in[-uncond.shape[0]:], cond={"c_crossattn": [uncond], "c_concat": [image_cond_in[-uncond.shape[0]:]]})
```
This PR adds support for such case. 

By the way, original code may have a bug of processing text-model-encoder: "This code evaluated twice in get_learned_conditioning." should be "This code evaluated X times in get_learned_conditioning, where X is the number of loaded loras":
https://github.com/opparco/stable-diffusion-webui-composable-lora/blob/11fe4cac71090c4069109179befb9a663d7249d9/composable_lora.py#L63-L83

Here is a example showing the effect of this fix:
Generate Info:
```
masterpiece, best quality, 3girls, outdoors, night, holding hands, looking at another, from side, looking away, eye contact, facing another, faceoff,
AND masterpiece, best quality, 3girls, upper body,  <lora:asoulBella_v10:1>, purple eyes, purple hair, navel, ribbon, holding hands, looking at another, from side, looking away, eye contact, facing another,
AND masterpiece, best quality, 3girls, upper body,  <lora:asoulEileenpicoLORA_v10:1>, blue eyes, white long hair, holding hands, looking at another, from side, looking away, eye contact, facing another,
AND masterpiece, best quality, 3girls, upper body,  <lora:chracterYukino_v10:1>, blue eyes, white long hair, holding hands, looking at another, from side, looking away, eye contact, facing another,
Negative prompt: ugly, huge eyes, worst face, (bad and mutated hands:1.3), (worst quality:2.0), (low quality:2.0), (blurry:2.0), horror, geometry, bad_prompt, (bad hands), (missing fingers), multiple limbs, bad anatomy, (interlocked fingers:1.2), Ugly Fingers, (extra digit and hands and fingers and legs and arms:1.4),(deformed fingers:1.2),(long fingers:1.2), (bad-artist-anime), bad-artist, bad hand,
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 661846343, Size: 768x512, Model hash: 6e430eb514, Denoising strength: 0.5, Clip skip: 2, ENSD: 31337, Latent Couple: "divisions=1:1,1:3,1:3,1:3 positions=0:0,0:0,0:1,0:2 weights=0.2,0.8,0.8,0.8 end at step=20", Hires upscale: 2, Hires steps: 10, Hires upscaler: SwinIR_4x
```
Before:
![image](https://user-images.githubusercontent.com/39763024/221176713-cac8c03e-1a3f-4064-9432-242cde962ecf.png)
After:
![image](https://user-images.githubusercontent.com/39763024/221176784-937ee002-5b81-4e51-acb2-586c6bba9da8.png)
